### PR TITLE
moved scripts off of root directory into scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+checkpoint-path/
+processed_data/
+wandb/
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 checkpoint-path/
+generation_outputs/
 processed_data/
 wandb/
 data/

--- a/CONSTANTS.py
+++ b/CONSTANTS.py
@@ -1,7 +1,7 @@
 # TODO adapt your paths to folder that contains the celer and zuco folders
 path_to_celer = ''  # e.g., path_to_celer = 'data/' if 'data/celer/...'
-path_to_zuco = ''   # e.g., path_to_zuco = 'data/' if 'data/zuco/...'
+path_to_zuco = 'data/' # e.g., path_to_zuco = 'data/' if 'data/zuco/...'
 
-PATH_TO_FIX = f'{path_to_celer}/celer/data_v2.0/data_v2.0/sent_fix.tsv'
-PATH_TO_IA = f'{path_to_celer}/celer/data_v2.0/data_v2.0/sent_ia.tsv'
+PATH_TO_FIX = f'{path_to_celer}/celer/data_v2.0/sent_fix.tsv'
+PATH_TO_IA = f'{path_to_celer}/celer/data_v2.0/sent_ia.tsv'
 SUB_METADATA_PATH = f'{path_to_celer}/celer/participant_metadata/metadata.tsv'

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ If you are using ScanDL, please consider citing our work:
 
 ## Acknowledgements
 
-As indicated in the paper, our code is based on the implementation of the [implementation](https://github.com/Shark-NLP/DiffuSeq) of [DiffuSeq](
+As indicated in the paper, our code is based on the [implementation](https://github.com/Shark-NLP/DiffuSeq) of [DiffuSeq](
 https://doi.org/10.48550/arXiv.2210.08933).
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # ScanDL
 
-This repository contains the code to reproduce the experiments in ScanDL: A Diffusion Model for Generating Synthetic Scanpaths on Texts.
+![scandl-output](img/scanpath-exp-regular.png)
+
+This repository contains the code to reproduce the experiments in [ScanDL: A Diffusion Model for Generating Synthetic Scanpaths on Texts](https://arxiv.org/abs/2310.15587).
 
 ## Summary
-![scandl-output](img/scanpath-exp-regular.png)
 * Our proposed model ScanDL is the first diffusion model for synthetic scanpath generation
 * ScanDL is able to exhibit human-like reading behavior
 
@@ -11,19 +12,26 @@ This repository contains the code to reproduce the experiments in ScanDL: A Diff
 
 ## Setup
 
+### Clone this repository
+
+```bash
+git clone git@github.com:dili-lab/scandl
+```
+
+
 ### Install requirements
 The code is based on the PyTorch and huggingface modules.
-```bash 
-pip install -r requirements.txt 
+```bash
+pip install -r requirements.txt
 ```
 
 ### Download data
 
-The CELER data can be downloaded from this [link](https://github.com/berzak/celer), where you need to execute ``python obtain_data.py``.<br>
+The CELER data can be downloaded from this [link](https://github.com/berzak/celer), where you need to follow the description.
 
-The ZuCo data can be downloaded from this [OSF repository](https://osf.io/q3zws/).<br>
+The ZuCo data can be downloaded from this [OSF repository](https://osf.io/q3zws/). You can use `scripts/get_zuco_data.sh` to automatically download the ZuCo data. Note, ZuCo is a big dataset and requires a lot of storage.
 
-Make sure you adapt the path to the folder that contains both the ```celer``` and the ```zuco``` in the file ```CONSTANTS.py```.<br>
+Make sure you adapt the path to the folder that contains both the ```celer``` and the ```zuco``` in the file ```CONSTANTS.py```. If you use aboves bash script `scripts/get_zuco_data.sh`, the `zuco` paths is `data/`.
 Make sure there are no whitespaces in the zuco directories (there might be when you download the data). You might want to check ```sp_load_celer_zuco.load_zuco()``` for the spelling of the directories.
 
 
@@ -33,83 +41,213 @@ Preprocessing the eye-tracking data takes time. It is thus recommended to perfor
 This not only saves time if training is performed several times but it also ensures the same data splits for each training run in the same setting.
 For preprocessing and saving the data, run
 ```bash
-python create_data_splits.py
+python -m scripts.create_data_splits
 ```
 
 ## Training
 
-Execute the following commands to perform the training:
-    *Notes:
-        * ```--nproc_per_node``` indicates the number of GPUs over which you want to split training.
-        * If you want to start multiple training processes at the same time, change ```--master_port``` to be different for all of them.
-        * ```--load_train_data processed_data``` means that the preprocessed data is loaded from the folder `processed_data`. If the data has not been preprocessed and saved, leave this argument away.<br>
+Execute the following commands to perform the training.
 
-New Reader setting
+### Notes
+- To execute the [training commands](#training-commands), you need GPUs setup with [CUDA](https://developer.nvidia.com/cuda-toolkit).
+- `--nproc_per_node` indicates the number of GPUs over which you want to split training.
+- If you want to start multiple training processes at the same time, change `--master_port` to be different for all of them.
+- `--load_train_data processed_data` means that the preprocessed data is loaded from the folder `processed_data`. If the data has not been preprocessed and saved, leave this argument away.
+
+## Training Commands
+To execute the training commands below, you need GPUs setup with [CUDA](https://developer.nvidia.com/cuda-toolkit).
+
+#### New Reader setting
 ```bash
-python -m torch.distributed.launch --nproc_per_node=4 --master_port=12233 --use_env scripts/sp_run_train.py --corpus celer --inference cv --load_train_data processed_data --num_transformer_heads 8 --num_transformer_layers 12 --hidden_dim 256 --noise_schedule sqrt --learning_steps 80000 --log_interval 500 --eval_interval 500 --save_interval 5000 --data_split_criterion reader
+python -m torch.distributed.launch \
+    --nproc_per_node=4 \
+    --master_port=12233 \
+    --use_env scripts/sp_run_train.py \
+    --corpus celer \
+    --inference cv \
+    --load_train_data processed_data \
+    --num_transformer_heads 8 \
+    --num_transformer_layers 12 \
+    --hidden_dim 256 \
+    --noise_schedule sqrt \
+    --learning_steps 80000 \
+    --log_interval 500 \
+    --eval_interval 500 \
+    --save_interval 5000 \
+    --data_split_criterion reader
 ```
 
-New Sentence setting
+#### New Sentence setting
 ```bash
-python -m torch.distributed.launch --nproc_per_node=4 --master_port=12233 --use_env scripts/sp_run_train.py --corpus celer --inference cv --load_train_data processed_data --num_transformer_heads 8 --num_transformer_layers 12 --hidden_dim 256 --noise_schedule sqrt --learning_steps 80000 --log_interval 500 --eval_interval 500 --save_interval 5000 --data_split_criterion sentence
+python -m torch.distributed.launch \
+    --nproc_per_node=4 \
+    --master_port=12233 \
+    --use_env scripts/sp_run_train.py \
+    --corpus celer \
+    --inference cv \
+    --load_train_data processed_data \
+    --num_transformer_heads 8 \
+    --num_transformer_layers 12 \
+    --hidden_dim 256 \
+    --noise_schedule sqrt \
+    --learning_steps 80000 \
+    --log_interval 500 \
+    --eval_interval 500 \
+    --save_interval 5000 \
+    --data_split_criterion sentence
 ```
 
-New Reader/New Sentence setting
+#### New Reader/New Sentence setting
 ```bash
-python -m torch.distributed.launch --nproc_per_node=4 --master_port=12233 --use_env scripts/sp_run_train.py --corpus celer --inference cv --load_train_data processed_data --num_transformer_heads 8 --num_transformer_layers 12 --hidden_dim 256 --noise_schedule sqrt --learning_steps 80000 --log_interval 500 --eval_interval 500 --save_interval 5000 --data_split_criterion combined
+python -m torch.distributed.launch \
+    --nproc_per_node=4 \
+    --master_port=12233 \
+    --use_env scripts/sp_run_train.py \
+    --corpus celer \
+    --inference cv \
+    --load_train_data processed_data \
+    --num_transformer_heads 8 \
+    --num_transformer_layers 12 \
+     --hidden_dim 256 \
+    --noise_schedule sqrt \
+    --learning_steps 80000 \
+    --log_interval 500 \
+    --eval_interval 500 \
+    --save_interval 5000 \
+    --data_split_criterion combined
 ```
 
-Cross-dataset setting
+#### Cross-dataset setting
 ```bash
-python -m torch.distributed.launch --nproc_per_node=4 --master_port=12233 --use_env scripts/sp_run_train.py --corpus celer --inference zuco --load_train_data processed_data --num_transformer_heads 8 --num_transformer_layers 12 --hidden_dim 256 --noise_schedule sqrt --learning_steps 80000 --log_interval 500 --eval_interval 500 --save_interval 5000 --notes cross_dataset --data_split_criterion scanpath
+python -m torch.distributed.launch \
+    --nproc_per_node=4 \
+    --master_port=12233 \
+    --use_env scripts/sp_run_train.py \
+    --corpus celer \
+    --inference zuco \
+    --load_train_data processed_data \
+    --num_transformer_heads 8 \
+    --num_transformer_layers 12 \
+    --hidden_dim 256 \
+    --noise_schedule sqrt \
+    --learning_steps 80000 \
+    --log_interval 500 \
+    --eval_interval 500 \
+    --save_interval 5000 \
+    --notes cross_dataset \
+    --data_split_criterion scanpath
 ```
 
-Ablation: without positional embedding and BERT embedding (New Reader/New Sentence)
+#### Ablation: without positional embedding and BERT embedding (New Reader/New Sentence)
 ```bash
-python -m torch.distributed.launch --nproc_per_node=4 --master_port=12233 --use_env scripts/sp_run_train_ablation.py --corpus celer --inference cv --load_train_data processed_data --num_transformer_heads 8 --num_transformer_layers 12 --hidden_dim 256 --noise_schedule sqrt --learning_steps 80000 --log_interval 50 --eval_interval 500 --save_interval 5000 --data_split_criterion combined --notes ablation-no-pos-bert
+python -m torch.distributed.launch \
+    --nproc_per_node=4 \
+    --master_port=12233 \
+    --use_env scripts/sp_run_train_ablation.py \
+    --corpus celer \
+    --inference cv \
+    --load_train_data processed_data \
+    --num_transformer_heads 8 \
+    --num_transformer_layers 12 \
+    --hidden_dim 256 \
+    --noise_schedule sqrt \
+    --learning_steps 80000 \
+    --log_interval 50 \
+    --eval_interval 500 \
+    --save_interval 5000 \
+    --data_split_criterion combined \
+    --notes ablation-no-pos-bert
 ```
 
-Ablation: without condition (sentence): unconditional scanpath generation (New Reader/New Sentence)
+#### Ablation: without condition (sentence): unconditional scanpath generation (New Reader/New Sentence)
 ```bash
-python -m torch.distributed.launch --nproc_per_node=4 --master_port=12233 --use_env scripts/sp_run_train_ablation_no_condition.py --corpus celer --inference cv --num_transformer_heads 8 --num_transformer_layers 12 --hidden_dim 256 --noise_schedule sqrt --learning_steps 80000 --log_interval 50 --eval_interval 500 --save_interval 5000 --data_split_criterion combined --notes ablation-no-condition
+python -m torch.distributed.launch \
+    --nproc_per_node=4 \
+    --master_port=12233 \
+    --use_env scripts/sp_run_train_ablation_no_condition.py \
+    --corpus celer \
+    --inference cv \
+    --num_transformer_heads 8 \
+    --num_transformer_layers 12 \
+    --hidden_dim 256 \
+    --noise_schedule sqrt \
+    --learning_steps 80000 \
+    --log_interval 50 \
+    --eval_interval 500 \
+    --save_interval 5000 \
+    --data_split_criterion combined \
+    --notes ablation-no-condition
 ```
 
-Ablation: cosine noise schedule (New Reader/New Sentence)
+#### Ablation: cosine noise schedule (New Reader/New Sentence)
 ```bash
-python -m torch.distributed.launch --nproc_per_node=4 --master_port=12233 --use_env scripts/sp_run_train.py --corpus celer --inference cv --load_train_data processed_data --num_transformer_heads 8 --num_transformer_layers 12 --hidden_dim 256 --noise_schedule cosine --learning_steps 80000 --log_interval 500 --eval_interval 500 --save_interval 5000 --data_split_criterion combined
+python -m torch.distributed.launch \
+    --nproc_per_node=4 \
+    --master_port=12233 \
+    --use_env scripts/sp_run_train.py \
+    --corpus celer \
+    --inference cv \
+    --load_train_data processed_data \
+    --num_transformer_heads 8 \
+    --num_transformer_layers 12 \
+    --hidden_dim 256 \
+    --noise_schedule cosine \
+    --learning_steps 80000 \
+    --log_interval 500 \
+    --eval_interval 500 \
+    --save_interval 5000 \
+    --data_split_criterion combined
 ```
 
-Ablation: linear noise schedule (New Reader/New Sentence)
+#### Ablation: linear noise schedule (New Reader/New Sentence)
 ```bash
-python -m torch.distributed.launch --nproc_per_node=4 --master_port=12233 --use_env scripts/sp_run_train.py --corpus celer --inference cv --load_train_data processed_data --num_transformer_heads 8 --num_transformer_layers 12 --hidden_dim 256 --noise_schedule linear --learning_steps 80000 --log_interval 500 --eval_interval 500 --save_interval 5000 --data_split_criterion combined
+python -m torch.distributed.launch \
+    --nproc_per_node=4 \
+    --master_port=12233 \
+    --use_env scripts/sp_run_train.py \
+    --corpus celer \
+    --inference cv \
+    --load_train_data processed_data \
+    --num_transformer_heads 8 \
+    --num_transformer_layers 12 \
+    --hidden_dim 256 \
+    --noise_schedule linear \
+    --learning_steps 80000 \
+    --log_interval 500 \
+    --eval_interval 500 \
+    --save_interval 5000 \
+    --data_split_criterion combined
 ```
 
 
 
 ## Inference
 
-To run the inference on the trained models, indicate the folder name within the ```checkpoint-path``` directory that refers to your trained model.
-* ```--no_gpus``` indicates the number of GPUs across which you split the inference. It is recommended to set it to 1; if inference is split on multiple GPUs, each process will produce a separate outfile which will have to be combined before evaluation can be run on them.
-* ```--bsz``` is the batch size.<br>
-* ```--cv``` must be given for the cross-validation settings and it is not given for the cross-dataset setting.<br>
-* ```--load_test_data processed_data``` is given if the data has been preprocessed and split and saved already before training; otherwise leave it away. It is never given for the ablation case of unconditional scanpath generation.<br>
+### NOTES
+- ```checkpoint-path``` to indicte the folder name within the  directory that refers to your trained model
+- ```--no_gpus``` indicates the number of GPUs across which you split the inference. It is recommended to set it to 1; if inference is split on multiple GPUs, each process will produce a separate output files which will have to be combined before evaluation can be run on them.
+- ```--bsz``` is the batch size.
+- ```--cv``` must be given for the cross-validation settings and it is not given for the cross-dataset setting.
+- ```--load_test_data processed_data``` is given if the data has been preprocessed and split and saved already before training; otherwise leave it away. It is never given for the ablation case of unconditional scanpath generation.
 
 If you run several inference processes at the same time, make sure to choose a different ```--seed``` for each of them. During training, the model is saved for many checkpoints. If you want to run inference on every checkpoint, leave the argument ```--run_only_on``` away. However, inference is quite costly time-wise and it is thus sensible to only
-specify certain checkpoints onto which inference should be run. For that purpose, the exact path to that saved model must be given.<br>
+specify certain checkpoints onto which inference should be run. For that purpose, the exact path to that saved model must be given.
 
 <br>
+
+### Inference Commands
 
 Adapt the following paths/variables:
 
-[MODEL_DIR]: 
+- [MODEL_DIR]
 
-[FOLD_IDX]: 
+- [FOLD_IDX]
 
-[STEPS]:
+- [STEPS]
 
 <br>
 
-For the settings: <br>
+For the settings:
 * New Reader
 * New Sentence
 * New Reader/New Sentence
@@ -117,22 +255,52 @@ For the settings: <br>
 * Ablation: linear noise schedule (New Reader/New Sentence)
 
 ```bash
-python -u scripts/sp_run_decode.py --model_dir checkpoint-path/[MODEL_DIR] --seed 60 --split test --cv --no_gpus 1 --bsz 24 --run_only_on 'checkpoint-path/[MODEL_DIR]/fold-[FOLD_IDX]/ema_0.9999_0[STEPS].pt' --load_test_data processed_data
+python -u scripts/sp_run_decode.py \
+    --model_dir checkpoint-path/[MODEL_DIR] \
+    --seed 60 \
+    --split test \
+    --cv \
+    --no_gpus 1 \
+    --bsz 24 \
+    --run_only_on 'checkpoint-path/[MODEL_DIR]/fold-[FOLD_IDX]/ema_0.9999_0[STEPS].pt' \
+    --load_test_data processed_data
 ```
 
 Cross-dataset:
 ```bash
-python -u scripts/sp_run_decode.py --model_dir checkpoint-path/[MODEL_DIR] --seed 60 --split test --bsz 24 --no_gpus 1 --run_only_on 'checkpoint-path/[MODEL_DIR]/ema_0.9999_0[STEPS].pt' --load_test_data processed_data
+python -u scripts/sp_run_decode.py \
+    --model_dir checkpoint-path/[MODEL_DIR] \
+    --seed 60 \
+    --split test \
+    --no_gpus 1 \
+    --bsz 24 \
+    --run_only_on 'checkpoint-path/[MODEL_DIR]/ema_0.9999_0[STEPS].pt' \
+    --load_test_data processed_data
 ```
 
 Ablation: without positional embedding and BERT embedding (New Reader/New Sentence)
 ```bash
-python -u scripts/sp_run_decode_ablation.py --model_dir checkpoint-path/[MODEL_DIR] --seed 60 --split test --cv --no_gpus 1 --bsz 24 --load_test_data processed_data --run_only_on 'checkpoint-path/[MODEL_DIR/fold-[FOLD_IDX]/ema_0.9999_0[STEPS].pt'
+python -u scripts/sp_run_decode_ablation.py \
+    --model_dir checkpoint-path/[MODEL_DIR] \
+    --seed 60 \
+    --split test \
+    --cv \
+    --no_gpus 1 \
+    --bsz 24 \
+    --load_test_data processed_data \
+    --run_only_on 'checkpoint-path/[MODEL_DIR/fold-[FOLD_IDX]/ema_0.9999_0[STEPS].pt'
 ```
 
 Ablation: without condition (sentence): unconditional scanpath generation (New Reader/New Sentence)
 ```bash
-python -u scripts/sp_run_decode_ablation_no_condition.py --model_dir checkpoint-path/[MODEL_DIR] --seed 62 --split test --cv --no_gpus 1 --bsz 16 --run_only_on 'checkpoint-path/[MODEL_DIR]/fold-[FOLD_IDX]/ema_0.9999_0[STEPS].pt'
+python -u scripts/sp_run_decode_ablation_no_condition.py \
+    --model_dir checkpoint-path/[MODEL_DIR] \
+    --seed 60 \
+    --split test \
+    --cv \
+    --no_gpus 1 \
+    --bsz 24 \
+    --run_only_on 'checkpoint-path/[MODEL_DIR]/fold-[FOLD_IDX]/ema_0.9999_0[STEPS].pt'
 ```
 
 
@@ -140,18 +308,18 @@ python -u scripts/sp_run_decode_ablation_no_condition.py --model_dir checkpoint-
 
 To run the evaluation on the ScanDL output, again indicate the model dir in ```generation_outputs```:<br>
 
-[MODEL_DIR]: 
+[MODEL_DIR]:
 
 The argument ```--cv``` should be used for the evaluation on all cross-validation settings. <br>
 
 For all cases except for the Cross-dataset:
 ```bash
-python sp_eval.py --generation_outputs [MODEL_DIR] --cv
+python -m scripts.sp_eval --generation_outputs [MODEL_DIR] --cv
 ```
 
 For the Cross-dataset setting:
 ```bash
-python sp_eval.py --generation_outputs [MODEL_DIR] 
+python -m scripts.sp_eval --generation_outputs [MODEL_DIR]
 ```
 
 
@@ -159,26 +327,28 @@ python sp_eval.py --generation_outputs [MODEL_DIR]
 
 To run the psycholinguistic analysis, first compute reading measures as well as psycholinguistic effects:<br>
 Set ```MODEL_DIR``` to be the model directory in ```generation_outputs```.<br>
-Set ```--seed``` to be the same seed as used during inference.
-Set ```--setting``` to be 'reader' for the New Reader setting, 'sentence' for the New Sentence setting, 'combined' for the 'New Reader/New Sentence setting', and 'cross_dataset' for cross dataset (train on celer, test on zuco).<br>
-Set ```--steps``` to be the number of training steps for the saved model checkpoint on which you have run the inference (e.g., 80000). <br>
 
-```bash 
-python pl_analysis/psycholinguistic_analysis.py --model [MODEL_DIR] --steps [N_STEPS] --setting [SETTING] --seed [SEED]
+### NOTES
+- ```--seed``` should be the same seed as used during inference.
+- ```--setting``` to 'reader' for the New Reader setting, 'sentence' for the New Sentence setting, 'combined' for the 'New Reader/New Sentence setting', and 'cross_dataset' for cross dataset (train on celer, test on zuco).
+- ```--steps``` to the number of training steps for the saved model checkpoint on which you have run the inference (e.g., 80000). 
+
+```bash
+python model_analyses/psycholinguistic_analysis.py --model [MODEL_DIR] --steps [N_STEPS] --setting [SETTING] --seed [SEED]
 ```
 
 The reading measure files will be stored in the directory `pl_analysis/reading_measures`.
 
 To fit the generalized linear models, run
-```bash 
-Rscript --vanilla pl_analysis/compute_effects.R --setting [SETTING] --steps [N_STEPS]
+```bash
+Rscript --vanilla model_analyses/compute_effects.R --setting [SETTING] --steps [N_STEPS]
 ```
 
 The fitted models will be saved as RDS-files in the directory `model_fits`.
 
 To compare the effect sizes between the different models, run
-```bash 
-Rscript --vanilla pl_analysis/analyze_fit.R --setting [SETTING] --steps [N_STEPS]
+```bash
+Rscript --vanilla model_analyses/analyze_fit.R --setting [SETTING] --steps [N_STEPS]
 ```
 
 ## Citation

--- a/model_analyses/model_inspection.py
+++ b/model_analyses/model_inspection.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 STOP_CHARS_SURP = []
 BASELINES = ['ez-reader', 'local', 'traindist', 'uniform', 'swift']
-Path("./pl_analysis/reading_measures").mkdir(exist_ok=True)
+Path("./pl_analysis/reading_measures").mkdir(parents=True, exist_ok=True)
 
 
 def get_average_over_sentlen(lst, sent_len):

--- a/model_analyses/psycholinguistic_analysis.py
+++ b/model_analyses/psycholinguistic_analysis.py
@@ -24,7 +24,7 @@ args = parser.parse_args()
 
 STOP_CHARS_SURP = []
 BASELINES = ['ez-reader', 'local', 'traindist', 'uniform', 'swift']
-Path("./pl_analysis/reading_measures").mkdir(exist_ok=True)
+Path("./pl_analysis/reading_measures").mkdir(parents=True, exist_ok=True)
 
 
 class ResultFiles:

--- a/pla_analyze_models.sh
+++ b/pla_analyze_models.sh
@@ -1,4 +1,0 @@
-nohup Rscript --vanilla pl_analysis/analyze_fit.R --setting reader --steps 50000 > log/p_reader.log&
-nohup Rscript --vanilla pl_analysis/analyze_fit.R --setting sentence --steps 50000 > log/p_sentence.log&
-nohup Rscript --vanilla pl_analysis/analyze_fit.R --setting combined --steps 50000 > p_combined.log&
-nohup Rscript --vanilla pl_analysis/analyze_fit.R --setting cross_dataset --steps 70000 > p_cross_dataset.log&

--- a/pla_fit_models.sh
+++ b/pla_fit_models.sh
@@ -1,6 +1,0 @@
-# Rscript --vanilla pl_analysis/compute_effects.R --setting combined --steps 80000 > combined_new.log&
-# Rscript --vanilla pl_analysis/compute_effects.R --setting traindist --steps 0 > traindist_new.log&
-# Rscript --vanilla pl_analysis/compute_effects.R --setting uniform --steps 0 > uniform_new.log&
-# Rscript --vanilla pl_analysis/compute_effects.R --setting local --steps 0 > eyettention_new.log&
-Rscript --vanilla pl_analysis/compute_effects.R --setting ez-reader --steps 0 > ez-reader_new.log
-Rscript --vanilla pl_analysis/compute_effects.R --setting swift --steps 0 > swift_new.log

--- a/pla_get_rm.sh
+++ b/pla_get_rm.sh
@@ -1,6 +1,0 @@
-# python pl_analysis/psycholinguistic_analysis.py --model traindist --seed 0
-#python pl_analysis/psycholinguistic_analysis.py --model uniform --seed 0
-#python pl_analysis/psycholinguistic_analysis.py --model local --seed 0
-# python pl_analysis/psycholinguistic_analysis.py --model scandl --steps 80000 --setting combined --seed 0
-python pl_analysis/psycholinguistic_analysis.py --model ez-reader --seed 0
-python pl_analysis/psycholinguistic_analysis.py --model swift --seed 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 blobfile==2.0.1
 datasets==2.10.1
+h5py
 numpy==1.23.4
 pandas==1.5.3
 plotly==5.17.0
 scikit-learn==1.2.2
 torch==2.0.0
-transformers==4.23.1
 tqdm==4.64.1
+transformers==4.23.1
 wandb==0.14.0
+wordfreq

--- a/scandl/sp_gaussian_diffusion.py
+++ b/scandl/sp_gaussian_diffusion.py
@@ -254,7 +254,7 @@ class GaussianDiffusion:
 
     def q_posterior_mean_variance(self, x_start, x_t, t):
         """
-        Compute the mean and variance of the diffusion posterior: 
+        Compute the mean and variance of the diffusion posterior:
             q(x_{t-1} | x_t, x_0)
 
         """
@@ -521,13 +521,13 @@ class GaussianDiffusion:
             sample = th.where(mask==0, x_start, sample)
 
         return {
-            "sample": sample, 
+            "sample": sample,
             "pred_xstart": out["pred_xstart"],
-            "greedy_mean": out["mean"], 
+            "greedy_mean": out["mean"],
             "out": out
         }
 
-    
+
     def p_sample_loop(
         self,
         model,
@@ -757,7 +757,7 @@ class GaussianDiffusion:
 
         else: # predict eps
             pred_xstart = self._predict_xstart_from_eps(x_t=x, t=t, eps=model_output)
-        
+
             pred_prev, _, _ = self.q_posterior_mean_variance(
                 x_start=pred_xstart, x_t=x, t=t
             )
@@ -926,12 +926,12 @@ class GaussianDiffusion:
         if langevin_fn:
             print(t.shape)
             sample=langevin_fn(sample, mean_pred, sigma, self.alphas_cumprod_prev[t[0]], t, x)
-        
+
         if mask == None:
             pass
         else:
             sample = th.where(mask==0, x_start, sample)
-        
+
         return {"sample": sample, "pred_xstart": out["pred_xstart"]}
 
     def ddim_reverse_sample(

--- a/scandl/sp_gaussian_diffusion_ablation_no_condition.py
+++ b/scandl/sp_gaussian_diffusion_ablation_no_condition.py
@@ -252,7 +252,7 @@ class GaussianDiffusion:
 
     def q_posterior_mean_variance(self, x_start, x_t, t):
         """
-        Compute the mean and variance of the diffusion posterior: 
+        Compute the mean and variance of the diffusion posterior:
             q(x_{t-1} | x_t, x_0)
 
         """
@@ -487,13 +487,13 @@ class GaussianDiffusion:
             sample = th.where(mask==0, x_start, sample)
 
         return {
-            "sample": sample, 
+            "sample": sample,
             "pred_xstart": out["pred_xstart"],
-            "greedy_mean": out["mean"], 
+            "greedy_mean": out["mean"],
             "out": out
         }
 
-    
+
     def p_sample_loop(
         self,
         model,
@@ -711,7 +711,7 @@ class GaussianDiffusion:
 
         else: # predict eps
             pred_xstart = self._predict_xstart_from_eps(x_t=x, t=t, eps=model_output)
-        
+
             pred_prev, _, _ = self.q_posterior_mean_variance(
                 x_start=pred_xstart, x_t=x, t=t
             )
@@ -862,12 +862,12 @@ class GaussianDiffusion:
         if langevin_fn:
             print(t.shape)
             sample=langevin_fn(sample, mean_pred, sigma, self.alphas_cumprod_prev[t[0]], t, x)
-        
+
         if mask == None:
             pass
         else:
             sample = th.where(mask==0, x_start, sample)
-        
+
         return {"sample": sample, "pred_xstart": out["pred_xstart"]}
 
     def ddim_reverse_sample(

--- a/scandl/utils/dist_util.py
+++ b/scandl/utils/dist_util.py
@@ -34,7 +34,7 @@ def setup_dist():
         port = _find_free_port()
         os.environ["MASTER_PORT"] = str(port)
         os.environ['LOCAL_RANK'] = str(0)
-    
+
     dist.init_process_group(backend=backend, init_method="env://")
 
     if th.cuda.is_available():  # This clears remaining caches in GPU 0

--- a/scandl/utils/losses.py
+++ b/scandl/utils/losses.py
@@ -84,7 +84,7 @@ def gaussian_density(x, *, means, log_scales):
     from torch.distributions import Normal
     normal_dist = Normal(means, log_scales.exp())
     logp = normal_dist.log_prob(x)
-    return logp 
+    return logp
 
 
 def discretized_text_log_likelihood(x, *, means, log_scales):
@@ -100,7 +100,7 @@ def discretized_text_log_likelihood(x, *, means, log_scales):
     """
     print(x.shape, means.shape)
     # assert x.shape == means.shape == log_scales.shape
-    print(x, means) 
+    print(x, means)
     centered_x = x - means
     inv_stdv = th.exp(-log_scales)
     plus_in = inv_stdv * (centered_x + 1.0 / 255.0)

--- a/scripts/get_zuco_data.sh
+++ b/scripts/get_zuco_data.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# this script only downloads, extracts, renames and preprocesses zuco 1
+# if you wish to also download, extract, rename and preprocess zuco 2 uncomment everything below
+mkdir -p data/zuco
+#
+# mkdir -p data/zuco2  # optional to also get zuco 2
+
+pip install osfclient
+
+for zuco_data in q3zws # 2urht  # optional to also get zuco2
+# do
+    osf -p $zuco_data clone
+    # if [ "$zuco_data" == "2urht" ];   # optional to also get zuco2then
+        for task in task1-\ SR task2\ -\ NR task3\ -\ TSR
+        do
+            mv $zuco_data"/osfstorage/$task" "data/zuco/"${task:0:5}
+            mv "data/zuco/${task:0:5}/Matlab files" "data/zuco/${task:0:5}/Matlab_files"
+        done
+    # else  # optional to also get zuco2
+        # for task in task1\ -\ NR task2\ -\ TSR  # optional to also get zuco2
+        # do  # optional to also get zuco2
+        #     mv $zuco_data"/osfstorage/$task" "data/zuco2/"${task:0:5}  # optional to also get zuco2
+        #     mv "data/zuco2/${task:0:5}/Matlab files" "data/zuco2/${task:0:5}/Matlab_files"  # optional to also get zuco2
+        # done  # optional to also get zuco2
+    # fi  # optional to also get zuco2
+done
+
+python3 -m scripts.zuco_create_wordinfor_scanpath_files --zuco-task zuco11
+python3 -m scripts.zuco_create_wordinfor_scanpath_files --zuco-task zuco12
+# python3 -m scripts.zuco_create_wordinfor_scanpath_files --zuco-task zuco21  # optional to also get zuco2

--- a/scripts/pla_analyze_models.sh
+++ b/scripts/pla_analyze_models.sh
@@ -1,0 +1,4 @@
+nohup Rscript --vanilla model_analyses/analyze_fit.R --setting reader --steps 50000 > log/p_reader.log&
+nohup Rscript --vanilla model_analyses/analyze_fit.R --setting sentence --steps 50000 > log/p_sentence.log&
+nohup Rscript --vanilla model_analyses/analyze_fit.R --setting combined --steps 50000 > p_combined.log&
+nohup Rscript --vanilla model_analyses/analyze_fit.R --setting cross_dataset --steps 70000 > p_cross_dataset.log&

--- a/scripts/pla_fit_models.sh
+++ b/scripts/pla_fit_models.sh
@@ -1,0 +1,6 @@
+Rscript --vanilla model_analyses/compute_effects.R --setting combined --steps 80000 > combined_new.log&
+Rscript --vanilla model_analyses/compute_effects.R --setting traindist --steps 0 > traindist_new.log&
+Rscript --vanilla model_analyses/compute_effects.R --setting uniform --steps 0 > uniform_new.log&
+Rscript --vanilla model_analyses/compute_effects.R --setting local --steps 0 > eyettention_new.log&
+Rscript --vanilla model_analyses/compute_effects.R --setting ez-reader --steps 0 > ez-reader_new.log
+Rscript --vanilla model_analyses/compute_effects.R --setting swift --steps 0 > swift_new.log

--- a/scripts/pla_get_rm.sh
+++ b/scripts/pla_get_rm.sh
@@ -1,0 +1,6 @@
+python model_analyses/psycholinguistic_analysis.py --model traindist --seed 0
+python model_analyses/psycholinguistic_analysis.py --model uniform --seed 0
+python model_analyses/psycholinguistic_analysis.py --model local --seed 0
+python model_analyses/psycholinguistic_analysis.py --model scandl --steps 80000 --setting combined --seed 0
+python model_analyses/psycholinguistic_analysis.py --model ez-reader --seed 0
+python model_analyses/psycholinguistic_analysis.py --model swift --seed 0

--- a/scripts/scanpath_similarity.py
+++ b/scripts/scanpath_similarity.py
@@ -10,6 +10,7 @@ def levenshtein_distance(gt: list[int], pred: list[int]) -> float:
 def levenshtein_similarity(gt: list[int], pred: list[int]) -> float:
     return textdistance.levenshtein.similarity(gt, pred)
 
+
 def levenshtein_normalized_similarity(gt: list[int], pred: list[int]) -> float:
     return textdistance.levenshtein.normalized_similarity(gt, pred)
 

--- a/scripts/sp_basic_utils.py
+++ b/scripts/sp_basic_utils.py
@@ -40,7 +40,7 @@ def create_model_and_diffusion(
 ):
     model = TransformerNetModel(
         input_dims=hidden_dim,
-        output_dims=(hidden_dim if not learn_sigma else hidden_dim*2),
+        output_dims=(hidden_dim if not learn_sigma else hidden_dim * 2),
         hidden_t_dim=hidden_t_dim,
         num_transformer_layers=num_transformer_layers,
         num_transformer_heads=num_transformer_heads,

--- a/scripts/sp_basic_utils_ablation.py
+++ b/scripts/sp_basic_utils_ablation.py
@@ -1,6 +1,7 @@
 import argparse
 import torch
-import json, os
+import json
+import os
 import time
 
 from scandl import sp_gaussian_diffusion as gd
@@ -42,7 +43,7 @@ def create_model_and_diffusion(
 ):
     model = TransformerNetModel(
         input_dims=hidden_dim,
-        output_dims=(hidden_dim if not learn_sigma else hidden_dim*2),
+        output_dims=(hidden_dim if not learn_sigma else hidden_dim * 2),
         hidden_t_dim=hidden_t_dim,
         num_transformer_layers=num_transformer_layers,
         num_transformer_heads=num_transformer_heads,

--- a/scripts/sp_basic_utils_ablation_no_condition.py
+++ b/scripts/sp_basic_utils_ablation_no_condition.py
@@ -40,7 +40,7 @@ def create_model_and_diffusion(
 ):
     model = TransformerNetModel(
         input_dims=hidden_dim,
-        output_dims=(hidden_dim if not learn_sigma else hidden_dim*2),
+        output_dims=(hidden_dim if not learn_sigma else hidden_dim * 2),
         hidden_t_dim=hidden_t_dim,
         num_transformer_layers=num_transformer_layers,
         num_transformer_heads=num_transformer_heads,

--- a/scripts/sp_eval.py
+++ b/scripts/sp_eval.py
@@ -7,7 +7,10 @@ import numpy as np
 import pandas as pd
 import json
 from argparse import ArgumentParser
-from scanpath_similarity import *
+from scripts.scanpath_similarity import levenshtein_distance
+from scripts.scanpath_similarity import levenshtein_similarity
+from scripts.scanpath_similarity import levenshtein_normalized_distance
+from scripts.scanpath_similarity import levenshtein_normalized_similarity
 
 
 def get_parser():
@@ -96,7 +99,6 @@ def main():
             metrics_filename = f'metrics_{args.generation_outputs}.csv'
 
         metrics_df.to_csv(os.path.join(path_to_outputs, metrics_filename), sep='\t')
-
 
     else:  # for all cross-validation settings
 

--- a/scripts/sp_run_decode.py
+++ b/scripts/sp_run_decode.py
@@ -94,8 +94,6 @@ def main():
 
     test_set_sns = args.unique_sns
 
-    output_lst = []
-
     if not args.cv:
 
         for lst in glob.glob(args.model_dir):
@@ -113,7 +111,7 @@ def main():
                     if checkpoint_one != args.run_only_on:
                         continue
 
-                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env sp_sample_seq2seq.py ' \
+                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq.py ' \
                           f'--model_path {checkpoint_one} --step {args.step} ' \
                           f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                           f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \
@@ -144,7 +142,7 @@ def main():
                         if checkpoint_one != args.run_only_on:
                             continue
 
-                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env sp_sample_seq2seq.py ' \
+                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq.py ' \
                               f'--model_path {checkpoint_one} --step {args.step} ' \
                               f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                               f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \

--- a/scripts/sp_run_decode.py
+++ b/scripts/sp_run_decode.py
@@ -111,7 +111,7 @@ def main():
                     if checkpoint_one != args.run_only_on:
                         continue
 
-                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq.py ' \
+                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env -m scripts.sp_sample_seq2seq ' \
                           f'--model_path {checkpoint_one} --step {args.step} ' \
                           f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                           f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \
@@ -142,7 +142,7 @@ def main():
                         if checkpoint_one != args.run_only_on:
                             continue
 
-                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq.py ' \
+                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env -m scripts.sp_sample_seq2seq ' \
                               f'--model_path {checkpoint_one} --step {args.step} ' \
                               f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                               f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \

--- a/scripts/sp_run_decode_ablation.py
+++ b/scripts/sp_run_decode_ablation.py
@@ -87,8 +87,6 @@ def main():
 
     test_set_sns = args.unique_sns
 
-    output_lst = []
-
     if not args.cv:
 
         for lst in glob.glob(args.model_dir):
@@ -106,7 +104,7 @@ def main():
                     if checkpoint_one != args.run_only_on:
                         continue
 
-                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env sp_sample_seq2seq_ablation.py ' \
+                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq_ablation.py ' \
                           f'--model_path {checkpoint_one} --step {args.step} ' \
                           f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                           f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \
@@ -137,7 +135,7 @@ def main():
                         if checkpoint_one != args.run_only_on:
                             continue
 
-                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env sp_sample_seq2seq_ablation.py ' \
+                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq_ablation.py ' \
                               f'--model_path {checkpoint_one} --step {args.step} ' \
                               f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                               f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \
@@ -149,7 +147,6 @@ def main():
                     os.system(COMMAND)
 
             print('#' * 30, 'decoding finished...')
-
 
 
 if __name__ == '__main__':

--- a/scripts/sp_run_decode_ablation.py
+++ b/scripts/sp_run_decode_ablation.py
@@ -104,7 +104,7 @@ def main():
                     if checkpoint_one != args.run_only_on:
                         continue
 
-                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq_ablation.py ' \
+                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env -m scripts.sp_sample_seq2seq_ablation ' \
                           f'--model_path {checkpoint_one} --step {args.step} ' \
                           f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                           f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \
@@ -135,7 +135,7 @@ def main():
                         if checkpoint_one != args.run_only_on:
                             continue
 
-                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq_ablation.py ' \
+                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env -m scripts.sp_sample_seq2seq_ablation ' \
                               f'--model_path {checkpoint_one} --step {args.step} ' \
                               f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                               f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \

--- a/scripts/sp_run_decode_ablation_no_condition.py
+++ b/scripts/sp_run_decode_ablation_no_condition.py
@@ -97,7 +97,7 @@ def main():
                     if checkpoint_one != args.run_only_on:
                         continue
 
-                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq_ablation_no_condition.py ' \
+                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env -m scripts.sp_sample_seq2seq_ablation_no_condition ' \
                           f'--model_path {checkpoint_one} --step {args.step} ' \
                           f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                           f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \
@@ -128,7 +128,7 @@ def main():
                         if checkpoint_one != args.run_only_on:
                             continue
 
-                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq_ablation_no_condition.py ' \
+                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env -m scripts.sp_sample_seq2seq_ablation_no_condition ' \
                               f'--model_path {checkpoint_one} --step {args.step} ' \
                               f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                               f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \

--- a/scripts/sp_run_decode_ablation_no_condition.py
+++ b/scripts/sp_run_decode_ablation_no_condition.py
@@ -80,8 +80,6 @@ def main():
 
     test_set_sns = args.unique_sns
 
-    output_lst = []
-
     if not args.cv:
 
         for lst in glob.glob(args.model_dir):
@@ -99,7 +97,7 @@ def main():
                     if checkpoint_one != args.run_only_on:
                         continue
 
-                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env sp_sample_seq2seq_ablation_no_condition.py ' \
+                COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq_ablation_no_condition.py ' \
                           f'--model_path {checkpoint_one} --step {args.step} ' \
                           f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                           f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \
@@ -130,7 +128,7 @@ def main():
                         if checkpoint_one != args.run_only_on:
                             continue
 
-                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env sp_sample_seq2seq_ablation_no_condition.py ' \
+                    COMMAND = f'python -m torch.distributed.launch --nproc_per_node={args.no_gpus} --master_port={22233 + int(args.seed)} --use_env scripts/sp_sample_seq2seq_ablation_no_condition.py ' \
                               f'--model_path {checkpoint_one} --step {args.step} ' \
                               f'--batch_size {args.bsz} --seed2 {args.seed} --split {args.split} ' \
                               f'--out_dir {out_dir} --top_p {args.top_p} --clamp_first {args.clamp_first} ' \

--- a/scripts/sp_run_train.py
+++ b/scripts/sp_run_train.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
             os.makedirs(model_file)
 
     COMMANDLINE = f'TOKENIZERS_PARALLELISM=FALSE ' \
-                  f'python sp_train.py ' \
+                  f'python -m scripts.sp_train ' \
                   f'--checkpoint_path {model_file} ' \
                   f'--vocab {args.vocab} ' \
                   f'--use_plm_init {args.use_plm_init} ' \

--- a/scripts/sp_run_train_ablation.py
+++ b/scripts/sp_run_train_ablation.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
             os.makedirs(model_file)
 
     COMMANDLINE = f'TOKENIZERS_PARALLELISM=FALSE ' \
-                  f'python sp_train_ablation.py ' \
+                  f'python -m scripts.sp_train_ablation ' \
                   f'--checkpoint_path {model_file} ' \
                   f'--vocab {args.vocab} ' \
                   f'--use_plm_init {args.use_plm_init} ' \

--- a/scripts/sp_run_train_ablation_no_condition.py
+++ b/scripts/sp_run_train_ablation_no_condition.py
@@ -90,7 +90,7 @@ if __name__ == '__main__':
             os.makedirs(model_file)
 
     COMMANDLINE = f'TOKENIZERS_PARALLELISM=FALSE ' \
-                  f'python sp_train_ablation_no_condition.py ' \
+                  f'python -m scripts.sp_train_ablation_no_condition ' \
                   f'--checkpoint_path {model_file} ' \
                   f'--vocab {args.vocab} ' \
                   f'--use_plm_init {args.use_plm_init} ' \

--- a/scripts/sp_sample_seq2seq_ablation.py
+++ b/scripts/sp_sample_seq2seq_ablation.py
@@ -1,10 +1,11 @@
 """
 Run inference on ScanDL.
-Ablation: without condition (sentence): unconditional scanpath generation (New Reader/New Sentence)
+Ablation: without positional embedding and BERT embedding (New Reader/New Sentence)
 """
 
 import argparse
-import os, json
+import os
+import json
 import sys
 import time
 
@@ -13,15 +14,15 @@ import torch.nn as nn
 import torch.distributed as dist
 from transformers import set_seed
 from datasets import load_from_disk
-from functools import partial
-from transformers import BertTokenizerFast, AutoConfig
+from transformers import BertTokenizerFast
 
 from scandl.sp_rounding import denoised_fn_round
+from scripts.sp_load_celer_zuco import celer_zuco_dataset_and_loader
+from visualizations.attention_visualization import attention_visualization
 from scandl.utils import dist_util, logger
 from scandl.utils.nn import *
-from sp_load_celer_zuco_ablation_no_condition import celer_zuco_dataset_and_loader
-from visualizations.attention_visualization import attention_visualization
-from sp_basic_utils_ablation_no_condition import (
+from functools import partial
+from scripts.sp_basic_utils_ablation import (
     load_defaults_config,
     create_model_and_diffusion,
     add_dict_to_argparser,
@@ -43,6 +44,7 @@ def get_parser() -> argparse.ArgumentParser:
         sp_vis=False,
         no_inst=0,
         atten_vis_sp=False,
+        load_test_data='-',
     )
     decode_defaults = dict(
         split='valid',
@@ -102,8 +104,6 @@ def main():
 
     model.eval().requires_grad_(False).to(dist_util.dev())
 
-    model_config = AutoConfig.from_pretrained(args.config_name)
-
     sn_sp_repr_embedding = nn.Embedding(
         num_embeddings=args.hidden_t_dim,
         embedding_dim=args.hidden_dim,
@@ -115,12 +115,20 @@ def main():
     print("### Sampling...on", args.split)
 
     if args.inference != 'cv':   # cross-dataset setting: train on celer, test on zuco
-        raise SystemExit('these ablation runs should be done on CV on celer only.')
+        raise SystemExit('this ablation case is supposed to be trained and tested on only on celer in CV')
 
     else:  # inference on the cross-validation settings
 
-        # load the test data that was split off from all data during training
-        test_data = load_from_disk(f'{args.checkpoint_path}/test_data')
+        if args.load_test_data != '-':
+            # load the test data that was saved and pre-processed even before training
+            fold = args.model_path.split('/')[-2]
+            path_to_data_dir = os.path.join(args.load_test_data, args.data_split_criterion, fold)
+            test_data = load_from_disk(os.path.join(path_to_data_dir, 'test_data'))
+            print('\t\t--- load test data from disk!')
+
+        else:
+            # load the test data that was split off from all data during training
+            test_data = load_from_disk(f'{args.checkpoint_path}/test_data')
 
         test_loader = celer_zuco_dataset_and_loader(
             data=test_data,
@@ -146,7 +154,7 @@ def main():
 
         out_path_incrementally_pad = os.path.join(out_path, f"seed{args.seed2}_step{args.clamp_step}_clamp-first-{args.clamp_first}_running_remove-PAD_rank{rank}.json")
         out_path_all_pad = os.path.join(out_path, f"seed{args.seed2}_step{args.clamp_step}_clamp-first-{args.clamp_first}_all_remove-PAD_rank{rank}.json")
-        out_path_incrementally_sep = os.path.join(out_path,  f"seed{args.seed2}_step{args.clamp_step}_clamp-first-{args.clamp_first}_running_cut-off-SEP_rank{rank}.json")
+        out_path_incrementally_sep = os.path.join(out_path, f"seed{args.seed2}_step{args.clamp_step}_clamp-first-{args.clamp_first}_running_cut-off-SEP_rank{rank}.json")
         out_path_all_sep = os.path.join(out_path, f"seed{args.seed2}_step{args.clamp_step}_clamp-first-{args.clamp_first}_all_cut-off-SEP_rank{rank}.json")
         if os.path.exists(out_path_all_pad):
             print(' --- inference has already been done on this output.')
@@ -217,9 +225,11 @@ def main():
                 dist.barrier()
             continue
 
-        sp_word_ids = batch['sp_word_ids'].to(dist_util.dev())
+        mask = batch['mask'].to(dist_util.dev())
+        sn_sp_repr = batch['sn_sp_repr'].to(dist_util.dev())
         sn_input_ids = batch['sn_input_ids'].to(dist_util.dev())
         indices_pos_enc = batch['indices_pos_enc'].to(dist_util.dev())
+        sn_repr_len = batch['sn_repr_len'].to(dist_util.dev())
         words_for_mapping = batch['words_for_mapping']
         sn_ids = batch['sn_ids']
         reader_ids = batch['reader_ids']
@@ -227,16 +237,18 @@ def main():
         # needed for attention visualisation
         subwords = [tokenizer.convert_ids_to_tokens(i) for i in sn_input_ids]
 
-        sn_sp_emb, pos_enc = model.get_embeds(
-            sn_sp_repr=sp_word_ids,
+        sn_sp_emb, pos_enc, sn_input_ids_emb = model.get_embeds(
+            sn_sp_repr=sn_sp_repr,
+            sn_input_ids=sn_input_ids,
             indices_pos_enc=indices_pos_enc,
         )
 
         x_start = sn_sp_emb
         noise = torch.randn_like(x_start)
+        mask = torch.broadcast_to(mask.unsqueeze(dim=-1), x_start.shape).to(dist_util.dev())
 
         # replace the scan path with Gaussian noise
-        x_noised = noise
+        x_noised = torch.where(mask == 0, x_start, noise)
 
         if args.step == args.diffusion_steps:
             args.use_ddim = False
@@ -255,7 +267,8 @@ def main():
             model=model,
             shape=sample_shape,
             noise=x_noised,
-            pos_enc=pos_enc,
+            sn_input_ids_emb=None,
+            pos_enc=None,
             mask_sn_padding=None,
             mask_transformer_att=None,
             clip_denoised=args.clip_denoised,
@@ -264,8 +277,8 @@ def main():
             top_p=args.top_p,
             clamp_step=args.clamp_step,
             clamp_first=clamp_first_bool,
-            mask=None,
-            x_start=None,
+            mask=mask,
+            x_start=x_start,
             subwords_list=subwords,
             atten_vis=args.atten_vis,
             atten_vis_fn=attention_visualization,
@@ -286,28 +299,34 @@ def main():
         logits = model.get_logits(sample)
         cands = torch.topk(logits, k=1, dim=-1)
 
-        for instance_idx, (pred_seq, orig_words, orig_ids, sn_id, reader_id) in enumerate(zip(
-                cands.indices, words_for_mapping, sp_word_ids, sn_ids, reader_ids
+        for instance_idx, (pred_seq, orig_words, orig_ids, sn_len, sn_id, reader_id) in enumerate(zip(
+                cands.indices, words_for_mapping, sn_sp_repr, sn_repr_len, sn_ids, reader_ids
         )):
 
-            pred_seq_sp = pred_seq
-            orig_ids_sp = orig_ids
+            pred_seq_sp = pred_seq[sn_len:]
+            orig_ids_sp = orig_ids[sn_len:]
+
+            # # # cut off all trailing PAD tokens # # #
 
             words_split = orig_words.split()
+            # map the predicted indices to the words
             predicted_sp = [words_split[i] for i in pred_seq_sp]
+            # the predicted sp IDs
             pred_sp_ids = [e.item() for e in pred_seq_sp]
+            # original scan path in words
             original_sp = [words_split[i] for i in orig_ids_sp]
+            # the original sp IDs
             orig_sp_ids = [e.item() for e in orig_ids_sp]
 
-            ### cut off all trailing PAD tokens ###
+            # # # cut off all trailing PAD tokens  # # #
 
             while len(predicted_sp) > 1 and predicted_sp[-1] == '[PAD]':
                 predicted_sp.pop()
-            while len(pred_sp_ids) > 1 and pred_sp_ids[-1] == args.seq_len-1:
+            while len(pred_sp_ids) > 1 and pred_sp_ids[-1] == args.seq_len - 1:
                 pred_sp_ids.pop()
             while len(original_sp) > 1 and original_sp[-1] == '[PAD]':
                 original_sp.pop()
-            while len(orig_sp_ids) > 1 and orig_sp_ids[-1] == args.seq_len-1:
+            while len(orig_sp_ids) > 1 and orig_sp_ids[-1] == args.seq_len - 1:
                 orig_sp_ids.pop()
             while len(words_split) > 1 and words_split[-1] == '[PAD]':
                 words_split.pop()
@@ -325,8 +344,12 @@ def main():
             original_sn_pad.append(' '.join(words_split))
 
             # add the IDs to the list
-            sn_ids_pad.append(sn_id)
-            reader_ids_pad.append(reader_id.item())
+            if args.inference == 'zuco':
+                reader_ids_pad.append(reader_id)
+                sn_ids_pad.append(sn_id.item())
+            else:
+                reader_ids_pad.append(reader_id.item())
+                sn_ids_pad.append(sn_id)
 
             if batch_idx == 0 and instance_idx == 0:
 
@@ -335,8 +358,14 @@ def main():
                 data_dict_initial_pad['predicted_sp_ids'].append(pred_sp_ids)
                 data_dict_initial_pad['original_sp_ids'].append(orig_sp_ids)
                 data_dict_initial_pad['original_sn'].append(' '.join(words_split))
-                data_dict_initial_pad['sn_ids'].append(sn_id)
-                data_dict_initial_pad['reader_ids'].append(reader_id.item())
+
+                if args.inference == 'zuco':
+                    data_dict_initial_pad['reader_ids'].append(reader_id)
+                    data_dict_initial_pad['sn_ids'].append(sn_id.item())
+                else:
+                    data_dict_initial_pad['reader_ids'].append(reader_id.item())
+                    data_dict_initial_pad['sn_ids'].append(sn_id)
+
                 for i in range(world_size):
                     if i == rank:
                         with open(out_path_incrementally_pad, 'w') as f:
@@ -356,8 +385,13 @@ def main():
                 loaded_data_dict['predicted_sp_ids'].append(pred_sp_ids)
                 loaded_data_dict['original_sp_ids'].append(orig_sp_ids)
                 loaded_data_dict['original_sn'].append(' '.join(words_split))
-                loaded_data_dict['sn_ids'].append(sn_id)
-                loaded_data_dict['reader_ids'].append(reader_id.item())
+
+                if args.inference == 'zuco':
+                    loaded_data_dict['reader_ids'].append(reader_id)
+                    loaded_data_dict['sn_ids'].append(sn_id.item())
+                else:
+                    loaded_data_dict['reader_ids'].append(reader_id.item())
+                    loaded_data_dict['sn_ids'].append(sn_id)
 
                 for i in range(world_size):
                     if i == rank:
@@ -365,8 +399,7 @@ def main():
                             json.dump(loaded_data_dict, f)
                     dist.barrier()
 
-
-            ### cut off at first SEP token ###
+            # # # cut off at first SEP token # # #
 
             words_split = orig_words.split()
             # map the predicted indices to the words
@@ -380,7 +413,7 @@ def main():
 
             while len(original_sp) > 1 and original_sp[-1] == '[PAD]':
                 original_sp.pop()
-            while len(orig_sp_ids) > 1 and orig_sp_ids[-1] == args.seq_len-1:
+            while len(orig_sp_ids) > 1 and orig_sp_ids[-1] == args.seq_len - 1:
                 orig_sp_ids.pop()
             while len(words_split) > 1 and words_split[-1] == '[PAD]':
                 words_split.pop()
@@ -388,12 +421,12 @@ def main():
 
             for idx, predicted_sp_id in enumerate(pred_sp_ids):
                 if predicted_sp_id == sep_token_id:
-                    pred_sp_ids = pred_sp_ids[:idx+1]
+                    pred_sp_ids = pred_sp_ids[:idx + 1]
                     break
 
             for idx, predicted_sp_word in enumerate(predicted_sp):
                 if predicted_sp_word == '[SEP]':
-                    predicted_sp = predicted_sp[:idx+1]
+                    predicted_sp = predicted_sp[:idx + 1]
                     break
 
             # predicted scan path in words
@@ -409,8 +442,12 @@ def main():
             original_sn_sep.append(' '.join(words_split))
 
             # add the IDs to the list
-            sn_ids_sep.append(sn_id)
-            reader_ids_sep.append(reader_ids)
+            if args.inference == 'zuco':
+                reader_ids_sep.append(reader_id)
+                sn_ids_sep.append(sn_id.item())
+            else:
+                reader_ids_sep.append(reader_id.item())
+                sn_ids_sep.append(sn_id)
 
             if batch_idx == 0 and instance_idx == 0:
 
@@ -419,8 +456,13 @@ def main():
                 data_dict_initial_sep['predicted_sp_ids'].append(pred_sp_ids)
                 data_dict_initial_sep['original_sp_ids'].append(orig_sp_ids)
                 data_dict_initial_sep['original_sn'].append(' '.join(words_split))
-                data_dict_initial_sep['sn_ids'].append(sn_id)
-                data_dict_initial_sep['reader_ids'].append(reader_id.item())
+
+                if args.inference == 'zuco':
+                    data_dict_initial_sep['reader_ids'].append(reader_id)
+                    data_dict_initial_sep['sn_ids'].append(sn_id.item())
+                else:
+                    data_dict_initial_sep['reader_ids'].append(reader_id.item())
+                    data_dict_initial_sep['sn_ids'].append(sn_id)
 
                 for i in range(world_size):
                     if i == rank:
@@ -441,8 +483,13 @@ def main():
                 loaded_data_dict['predicted_sp_ids'].append(pred_sp_ids)
                 loaded_data_dict['original_sp_ids'].append(orig_sp_ids)
                 loaded_data_dict['original_sn'].append(' '.join(words_split))
-                loaded_data_dict['sn_ids'].append(sn_id)
-                loaded_data_dict['reader_ids'].append(reader_id.item())
+
+                if args.inference == 'zuco':
+                    loaded_data_dict['reader_ids'].append(reader_id)
+                    loaded_data_dict['sn_ids'].append(sn_id.item())
+                else:
+                    loaded_data_dict['reader_ids'].append(reader_id.item())
+                    loaded_data_dict['sn_ids'].append(sn_id)
 
                 for i in range(world_size):
                     if i == rank:
@@ -451,9 +498,11 @@ def main():
                     dist.barrier()
 
         del batch
-        del sp_word_ids
+        del mask
+        del sn_sp_repr
         del sn_input_ids
         del indices_pos_enc
+        del sn_repr_len
         del words_for_mapping
         del x_start
         del noise

--- a/scripts/sp_train.py
+++ b/scripts/sp_train.py
@@ -1,5 +1,9 @@
 """
-Train ScanDL for the ablation case: without word embeddings and without BERT embeddings
+Train ScanDL for scanpath generation conditioned on text input in the following settings:
+New Reader
+New Sentence
+New Reader / New Sentence
+Cross-Dataset
 """
 
 import argparse
@@ -8,26 +12,28 @@ import os
 import numpy as np
 import wandb
 
+import torch
 import torch.distributed as dist
 from sklearn.model_selection import train_test_split
-from transformers import set_seed, BertTokenizerFast, BertConfig
+from transformers import set_seed, BertTokenizerFast
 from datasets import load_from_disk
 
 from scandl.utils import dist_util, logger
 from scandl.step_sample import create_named_schedule_sampler
-from sp_basic_utils_ablation import (
+from scripts.sp_basic_utils import (
     load_defaults_config,
     create_model_and_diffusion,
     args_to_dict,
     add_dict_to_argparser,
 )
-from sp_train_util import TrainLoop
-from sp_load_celer_zuco import load_celer, load_celer_speakers, process_celer, celer_zuco_dataset_and_loader
-from sp_load_celer_zuco import get_kfold, get_kfold_indices_combined
-from sp_load_celer_zuco import flatten_data, unflatten_data
+from scripts.sp_train_util import TrainLoop
+from scripts.sp_load_celer_zuco import load_celer, load_celer_speakers, process_celer, celer_zuco_dataset_and_loader
+from scripts.sp_load_celer_zuco import get_kfold, get_kfold_indices_combined
+from scripts.sp_load_celer_zuco import flatten_data, unflatten_data
 
 
 os.environ["WANDB_MODE"] = "offline"
+
 
 def create_argparser():
     """ Loads the config from the file scandl/config.json and adds all keys and values in the config dict
@@ -51,7 +57,6 @@ def main():
     logger.configure()
     logger.log("### Creating data loader...")
 
-    world_size = dist.get_world_size() or 1  # the number of processes in the current process group
     rank = dist.get_rank() or 0
 
     tokenizer = BertTokenizerFast.from_pretrained(args.config_name)
@@ -62,8 +67,113 @@ def main():
         if not os.path.exists(args.checkpoint_path):
             os.makedirs(args.checkpoint_path)
 
-    if args.inference != 'cv':
-        raise NotImplementedError('This ablation case runs in the cross-validation setting of New Reader/New Sentence')
+    if args.inference != 'cv':  # Train in Cross-Dataset setting
+
+        if args.load_train_data == '-':
+            if args.inference == 'zuco':
+
+                if args.corpus == 'zuco':
+                    raise RuntimeError('Training and inference cannot be done on the same corpus if not CV.')
+
+                else:
+                    split_sizes = {'val_size': 0.1}
+
+                    if args.corpus == 'celer':
+                        word_info_df, eyemovement_df = load_celer()
+                        reader_list = load_celer_speakers(only_native_speakers=args.celer_only_L1)
+                        # list with unique sentences / sentence IDs
+                        sn_list = np.unique(word_info_df[word_info_df['list'].isin(reader_list)].sentenceid.values).tolist()
+
+                        train_data, val_data = process_celer(
+                            sn_list=sn_list,
+                            reader_list=reader_list,
+                            word_info_df=word_info_df,
+                            eyemovement_df=eyemovement_df,
+                            tokenizer=tokenizer,
+                            args=args,
+                            split='train-val',
+                            split_sizes=split_sizes,
+                            splitting_criterion=args.data_split_criterion,
+                        )
+                        train_data.save_to_disk(os.path.join(args.checkpoint_path, 'train_data'))
+                        val_data.save_to_disk(os.path.join(args.checkpoint_path, 'val_data'))
+
+        else:  # load preprocessed and saved data
+
+            path_to_data_dir = os.path.join(args.load_train_data, 'cross_dataset')
+            train_data = load_from_disk(os.path.join(path_to_data_dir, 'train_data'))
+            val_data = load_from_disk(os.path.join(path_to_data_dir, 'val_data'))
+            print('\t\t--- load data from disk!')
+
+        train_loader = celer_zuco_dataset_and_loader(
+            data=train_data,
+            data_args=args,
+            split='train',
+        )
+        val_loader = celer_zuco_dataset_and_loader(
+            data=val_data,
+            data_args=args,
+            split='val',
+        )
+
+        logger.log("### Creating model and diffusion...")
+        if torch.cuda.is_available():
+            print('#' * 30, 'CUDA_VISIBLE_DEVICES', os.environ['CUDA_VISIBLE_DEVICES'])
+
+        model, diffusion = create_model_and_diffusion(
+            **args_to_dict(args, load_defaults_config().keys())
+        )
+
+        if args.load_from_checkpoint:
+            print('\t--- load model from pretrained checkpoint:', end=' ')
+            path_to_pretrained = args.load_trained_model
+            model.load_state_dict(
+                dist_util.load_state_dict(path_to_pretrained)
+            )
+            print(path_to_pretrained)
+
+        model.to(dist_util.dev())
+
+        pytorch_total_params = sum(p.numel() for p in model.parameters())
+
+        logger.log(f'### The parameter count is {pytorch_total_params}')
+        # args.schedule_sampler = lossaware
+        schedule_sampler = create_named_schedule_sampler(args.schedule_sampler, diffusion)
+
+        logger.log(f'### Saving the hyperparameters to {args.checkpoint_path}/training_args.json')
+        with open(f'{args.checkpoint_path}/training_args.json', 'w') as f:
+            json.dump(args.__dict__, f, indent=2)
+
+        if ('LOCAL_RANK' not in os.environ) or (int(os.environ['LOCAL_RANK']) == 0):
+            wandb.init(
+                project=os.getenv("WANDB_PROJECT", "ScanDL"),
+                name=args.checkpoint_path,
+            )
+            wandb.config.update(args.__dict__, allow_val_change=True)
+
+        logger.log('### Training...')
+
+        TrainLoop(
+            model=model,
+            diffusion=diffusion,
+            data=train_loader,
+            batch_size=args.batch_size,
+            microbatch=args.microbatch,
+            lr=args.lr,
+            ema_rate=args.ema_rate,
+            log_interval=args.log_interval,
+            save_interval=args.save_interval,
+            resume_checkpoint=args.resume_checkpoint,
+            use_fp16=args.use_fp16,
+            fp16_scale_growth=args.fp16_scale_growth,
+            schedule_sampler=schedule_sampler,
+            weight_decay=args.weight_decay,
+            learning_steps=args.learning_steps,
+            checkpoint_path=args.checkpoint_path,
+            gradient_clipping=args.gradient_clipping,
+            eval_data=val_loader,
+            eval_interval=args.eval_interval,
+        ).run_loop()
 
     else:  # performing k-fold cross-validation (New Reader, New Sentence, New Reader/New Sentence)
 
@@ -78,7 +188,6 @@ def main():
             sn_list = np.unique(word_info_df[word_info_df['list'].isin(reader_list)].sentenceid.values).tolist()
 
             if args.load_train_data == '-':
-
                 data, splitting_IDs_dict = process_celer(
                     sn_list=sn_list,
                     reader_list=reader_list,
@@ -121,8 +230,7 @@ def main():
                         train_data_save.save_to_disk(os.path.join(args.checkpoint_path, 'train_data'))
 
                         # split train data into train and val data
-                        train_data, val_data = train_test_split(train_data, test_size=0.1, shuffle=True,
-                                                                random_state=77)
+                        train_data, val_data = train_test_split(train_data, test_size=0.1, shuffle=True, random_state=77)
 
                         # unflatten the data
                         train_data = unflatten_data(flattened_data=train_data, split='train')
@@ -144,7 +252,8 @@ def main():
                         )
 
                         logger.log("### Creating model and diffusion...")
-                        print('#' * 30, 'CUDA_VISIBLE_DEVICES', os.environ['CUDA_VISIBLE_DEVICES'])
+                        if torch.cuda.is_available():
+                            print('#' * 30, 'CUDA_VISIBLE_DEVICES', os.environ['CUDA_VISIBLE_DEVICES'])
 
                         model, diffusion = create_model_and_diffusion(
                             **args_to_dict(args, load_defaults_config().keys())
@@ -192,8 +301,7 @@ def main():
                             eval_interval=args.eval_interval,
                         ).run_loop()
 
-
-                else:
+                else:  # New Reader/New Sentence setting
 
                     reader_indices, sentence_indices = get_kfold_indices_combined(
                         data=flattened_data,
@@ -221,6 +329,7 @@ def main():
                         # add the data point to the test data; if it is in neither of them, add to train data. if
                         # in one of them, unfortunately discard
                         train_data, test_data = list(), list()
+
                         for i in range(len(flattened_data)):
                             if reader_IDs[i] in unique_reader_test_IDs and sn_IDs[i] in unique_sn_test_IDs:
                                 test_data.append(flattened_data[i])
@@ -228,7 +337,6 @@ def main():
                                 train_data.append(flattened_data[i])
                             else:
                                 continue
-
                         train_data_save = unflatten_data(flattened_data=train_data, split='train')
                         train_data_save.save_to_disk(os.path.join(args.checkpoint_path, 'train_data'))
 
@@ -255,7 +363,8 @@ def main():
                         )
 
                         logger.log("### Creating model and diffusion...")
-                        print('#' * 30, 'CUDA_VISIBLE_DEVICES', os.environ['CUDA_VISIBLE_DEVICES'])
+                        if torch.cuda.is_available():
+                            print('#' * 30, 'CUDA_VISIBLE_DEVICES', os.environ['CUDA_VISIBLE_DEVICES'])
 
                         model, diffusion = create_model_and_diffusion(
                             **args_to_dict(args, load_defaults_config().keys())
@@ -308,22 +417,21 @@ def main():
                 original_checkpoint_path = args.checkpoint_path
                 path_to_data_dir = os.path.join(args.load_train_data, args.data_split_criterion)
                 folds = [dir for dir in os.listdir(path_to_data_dir) if dir.startswith('fold')]
-
                 for fold_idx, fold in enumerate(folds):
-
                     path_to_data_fold = os.path.join(path_to_data_dir, fold)
+
                     fold_path = os.path.join(f'{original_checkpoint_path}', f'fold-{fold_idx}')
                     args.checkpoint_path = fold_path
 
                     if rank == 0:  # avoid file exists errors when parallelising
                         if not os.path.exists(args.checkpoint_path):
                             os.makedirs(args.checkpoint_path)
+
                     print('\t\t--- load train data from disk!')
                     train_data = load_from_disk(os.path.join(path_to_data_fold, 'train_data'))
                     print('\t\t--- loaded train data from disk!')
                     flattened_data = flatten_data(train_data['train'].to_dict())
-                    train_data, val_data = train_test_split(flattened_data, test_size=0.1, shuffle=True,
-                                                            random_state=77)
+                    train_data, val_data = train_test_split(flattened_data, test_size=0.1, shuffle=True, random_state=77)
 
                     # unflatten the data
                     train_data = unflatten_data(flattened_data=train_data, split='train')
@@ -341,7 +449,8 @@ def main():
                     )
 
                     logger.log("### Creating model and diffusion...")
-                    print('#' * 30, 'CUDA_VISIBLE_DEVICES', os.environ['CUDA_VISIBLE_DEVICES'])
+                    if torch.cuda.is_available():
+                        print('#' * 30, 'CUDA_VISIBLE_DEVICES', os.environ['CUDA_VISIBLE_DEVICES'])
 
                     model, diffusion = create_model_and_diffusion(
                         **args_to_dict(args, load_defaults_config().keys())
@@ -391,4 +500,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())

--- a/scripts/sp_train_ablation_no_condition.py
+++ b/scripts/sp_train_ablation_no_condition.py
@@ -10,23 +10,24 @@ import wandb
 
 import torch.distributed as dist
 from sklearn.model_selection import train_test_split
-from transformers import set_seed, BertTokenizerFast, BertConfig
+from transformers import set_seed, BertTokenizerFast
 
 from scandl.utils import dist_util, logger
 from scandl.step_sample import create_named_schedule_sampler
-from sp_basic_utils_ablation_no_condition import (
+from scripts.sp_basic_utils_ablation_no_condition import (
     load_defaults_config,
     create_model_and_diffusion,
     args_to_dict,
     add_dict_to_argparser,
 )
-from sp_train_util_ablation_no_condition import TrainLoop
-from sp_load_celer_zuco_ablation_no_condition import load_celer, load_celer_speakers, process_celer, celer_zuco_dataset_and_loader
-from sp_load_celer_zuco_ablation_no_condition import  get_kfold, get_kfold_indices_combined
-from sp_load_celer_zuco_ablation_no_condition import flatten_data, unflatten_data
+from scripts.sp_train_util_ablation_no_condition import TrainLoop
+from scripts.sp_load_celer_zuco_ablation_no_condition import load_celer, load_celer_speakers, process_celer, celer_zuco_dataset_and_loader
+from scripts.sp_load_celer_zuco_ablation_no_condition import get_kfold, get_kfold_indices_combined
+from scripts.sp_load_celer_zuco_ablation_no_condition import flatten_data, unflatten_data
 
 
 os.environ["WANDB_MODE"] = "offline"
+
 
 def create_argparser():
     """ Loads the config from the file scandl/config.json and adds all keys and values in the config dict
@@ -49,7 +50,6 @@ def main():
     logger.configure()
     logger.log("### Creating data loader...")
 
-    world_size = dist.get_world_size() or 1  # the number of processes in the current process group
     rank = dist.get_rank() or 0
 
     tokenizer = BertTokenizerFast.from_pretrained(args.config_name)
@@ -63,8 +63,6 @@ def main():
     if args.inference != 'cv':
 
         raise NotImplementedError('This ablation case runs in the cross-validation setting of New Reader/New Sentence')
-
-
 
     else:  # performing k-fold cross-validation (New Reader, New Sentence, New Reader/New Sentence)
 
@@ -190,7 +188,6 @@ def main():
                         eval_interval=args.eval_interval,
                     ).run_loop()
 
-
             else:
 
                 reader_indices, sentence_indices = get_kfold_indices_combined(
@@ -303,6 +300,5 @@ def main():
                     ).run_loop()
 
 
-
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())

--- a/scripts/sp_train_util_ablation_no_condition.py
+++ b/scripts/sp_train_util_ablation_no_condition.py
@@ -22,6 +22,7 @@ from scandl.step_sample import LossAwareSampler, UniformSampler
 
 INITIAL_LOG_LOSS_SCALE = 20.0
 
+
 class TrainLoop:
     def __init__(
         self,
@@ -78,7 +79,7 @@ class TrainLoop:
         self.lg_loss_scale = INITIAL_LOG_LOSS_SCALE
         self.sync_cuda = th.cuda.is_available()
 
-        self.checkpoint_path = checkpoint_path # DEBUG **
+        self.checkpoint_path = checkpoint_path  # DEBUG **
 
         self._load_and_sync_parameters()
         if self.use_fp16:
@@ -100,7 +101,7 @@ class TrainLoop:
                 copy.deepcopy(self.master_params) for _ in range(len(self.ema_rate))
             ]
 
-        if th.cuda.is_available(): # DEBUG **
+        if th.cuda.is_available():  # DEBUG **
             self.use_ddp = True
             print(dist_util.dev())
             # Distributed Data Parallel
@@ -167,8 +168,7 @@ class TrainLoop:
 
     def run_loop(self):
         while (
-            not self.learning_steps
-            or self.step + self.resume_step < self.learning_steps
+            not self.learning_steps or self.step + self.resume_step < self.learning_steps
         ):
             batch = next(self.data)
             self.run_step(batch)
@@ -207,8 +207,7 @@ class TrainLoop:
             for i in range(0, batch['sp_word_ids'].shape[0], self.microbatch):
 
                 indices_pos_enc = batch['indices_pos_enc'][i:i + self.microbatch].to(dist_util.dev())
-                sn_repr_len = batch['sn_repr_len'][i:i + self.microbatch].to(dist_util.dev())
-                sp_word_ids = batch['sp_word_ids'][i:i+self.microbatch].to(dist_util.dev())
+                sp_word_ids = batch['sp_word_ids'][i:i + self.microbatch].to(dist_util.dev())
                 mask_transformer_att = batch['mask_transformer_att'][i:i + self.microbatch].to(dist_util.dev())
 
                 last_batch = (i + self.microbatch) >= sp_word_ids.shape[0]
@@ -232,7 +231,6 @@ class TrainLoop:
                     self.diffusion, t, {f'eval_{k}': v * weights for k, v in losses.items()}
                 )
 
-
     def forward_backward(
             self,
             batch,
@@ -241,9 +239,9 @@ class TrainLoop:
 
         for i in range(0, batch['sp_word_ids'].shape[0], self.microbatch):
 
-            indices_pos_enc = batch['indices_pos_enc'][i:i+self.microbatch].to(dist_util.dev())
-            sp_word_ids = batch['sp_word_ids'][i:i+self.microbatch].to(dist_util.dev())
-            mask_transformer_att = batch['mask_transformer_att'][i:i+self.microbatch].to(dist_util.dev())
+            indices_pos_enc = batch['indices_pos_enc'][i:i + self.microbatch].to(dist_util.dev())
+            sp_word_ids = batch['sp_word_ids'][i:i + self.microbatch].to(dist_util.dev())
+            mask_transformer_att = batch['mask_transformer_att'][i:i + self.microbatch].to(dist_util.dev())
 
             last_batch = (i + self.microbatch) >= sp_word_ids.shape[0]
             t, weights = self.schedule_sampler.sample(sp_word_ids.shape[0], dist_util.dev())
@@ -297,7 +295,7 @@ class TrainLoop:
 
     def grad_clip(self):
         # print('doing gradient clipping')
-        max_grad_norm=self.gradient_clipping #3.0
+        max_grad_norm = self.gradient_clipping  # 3.0
         if hasattr(self.opt, "clip_grad_norm"):
             # Some optimizers (like the sharded optimizer) have a specific way to do gradient clipping
             self.opt.clip_grad_norm(max_grad_norm)
@@ -309,7 +307,7 @@ class TrainLoop:
         else:
             # Revert to normal clipping otherwise, handling Apex or full precision
             th.nn.utils.clip_grad_norm_(
-                self.model.parameters(), #amp.master_params(self.opt) if self.use_apex else
+                self.model.parameters(),  # amp.master_params(self.opt) if self.use_apex else
                 max_grad_norm,
             )
 
@@ -331,7 +329,7 @@ class TrainLoop:
             # print(cnt, p) ## DEBUG
             # print(cnt, p.grad)
             # cnt += 1
-            if p.grad != None:
+            if p.grad is not None:
                 sqsum += (p.grad ** 2).sum().item()
         logger.logkv_mean("grad_norm", np.sqrt(sqsum))
 
@@ -362,8 +360,8 @@ class TrainLoop:
                 print('writing to', bf.join(self.checkpoint_path, filename))
                 # with bf.BlobFile(bf.join(get_blob_logdir(), filename), "wb") as f:
                 #     th.save(state_dict, f)
-                with bf.BlobFile(bf.join(self.checkpoint_path, filename), "wb") as f: # DEBUG **
-                    th.save(state_dict, f) # save locally
+                with bf.BlobFile(bf.join(self.checkpoint_path, filename), "wb") as f:  # DEBUG **
+                    th.save(state_dict, f)  # save locally
                     # pass # save empty
 
         # save_checkpoint(0, self.master_params)
@@ -375,7 +373,7 @@ class TrainLoop:
     def _master_params_to_state_dict(self, master_params):
         if self.use_fp16:
             master_params = unflatten_master_params(
-                list(self.model.parameters()), master_params # DEBUG **
+                list(self.model.parameters()), master_params  # DEBUG **
             )
         state_dict = self.model.state_dict()
         for i, (name, _value) in enumerate(self.model.named_parameters()):
@@ -433,6 +431,3 @@ def log_loss_dict(diffusion, ts, losses):
 
 def actual_model_path(model_path):
     return model_path
-
-
-

--- a/scripts/zuco_create_wordinfor_scanpath_files.py
+++ b/scripts/zuco_create_wordinfor_scanpath_files.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import argparse
+import os
+
+import h5py
+import numpy as np
+import pandas as pd
+import scipy.io as io
+from tqdm import tqdm
+
+import CONSTANTS as C
+
+
+def ZUCO_read_words(directory: str, task: str) -> None:
+    # task: zuco11, zuco12, zuco21
+    if task.startswith('zuco1'):
+        full_subj = 'ZAB'  # subject with complete data
+        # full_subj = "ZKW"
+        directory = directory + 'zuco/'
+    elif task == 'zuco21':
+        full_subj = 'YAG'
+        directory = directory + 'zuco2/'
+    else:
+        raise NotImplementedError(f'{task=} unknown')
+    directory = os.path.join(directory, f'task{task[-1]}', 'Matlab_files')
+    save_path = directory + '/Word_Infor.csv'
+    sub_file_path = {}
+    for file in sorted(os.listdir(directory)):
+        if not file.endswith('.mat'):
+            continue
+        subj = file.split('_')[0][-3:]
+        fpath = os.path.join(directory, file)
+        sub_file_path[subj] = fpath
+
+    # read words
+    df = pd.DataFrame([], columns=['SN', 'NW', 'WORD'])
+    if task.startswith('zuco1'):
+        sentence_data = io.loadmat(
+            sub_file_path[full_subj], squeeze_me=True, struct_as_record=False,
+        )['sentenceData']
+        for sn_idx in range(len(sentence_data)):
+            sn_data = sentence_data[sn_idx]
+            # print(sn_data._fieldnames)
+            word_data = sn_data.word
+            for word_idx in range(len(word_data)):
+                df_tmp = pd.DataFrame(
+                    [[sn_idx + 1, word_idx + 1, word_data[word_idx].content]],
+                    columns=['SN', 'NW', 'WORD'],
+                )
+
+                df = pd.concat([df, df_tmp])
+
+    else:
+        mat = h5py.File(sub_file_path[full_subj])
+        sentence_data = mat['sentenceData/word']
+        for sn_idx in range(len(sentence_data)):
+            sn_data = sentence_data[sn_idx]
+            word_data = mat[sn_data[0]]['content']
+            for word_idx in range(len(word_data)):
+                item = word_data[word_idx]
+                word = ''.join(chr(c) for c in mat[item[0]][()].reshape(-1))
+                df_tmp = pd.DataFrame(
+                    [[sn_idx + 1, word_idx + 1, word]], columns=['SN', 'NW', 'WORD'],
+                )
+                df = pd.concat([df, df_tmp])
+    df.to_csv(save_path, sep='\t', index=False)
+
+
+def add_word_len(directory, task):
+    if task.startswith('zuco1'):
+        directory = directory + 'zuco/'
+    elif task == 'zuco21':
+        directory = directory + 'zuco2/'
+    else:
+        raise NotImplementedError(f'{task=} unknown')
+    directory = os.path.join(directory, f'task{task[-1]}', 'Matlab_files')
+    word_infor_path = directory + '/Word_Infor.csv'
+    word_infor_df = pd.read_csv(word_infor_path, sep='\t')
+    word_infor_df['word_len'] = np.array(
+        [len(word) for word in word_infor_df['WORD'].values],
+    )
+    word_infor_df.to_csv(word_infor_path, sep='\t', index=False)
+
+
+def ZUCO_read_scanpath(directory, task):
+    # TODO: ZUCO2: exclude YMH due to incomplete data because of dyslexia
+    # if subject != 'YMH': already cleaned up in the dataset
+    # task: zuco11, zuco12, zuco21
+    if task.startswith('zuco1'):
+        directory = directory + 'zuco/'
+    elif task == 'zuco21':
+        directory = directory + 'zuco2/'
+    else:
+        raise NotImplementedError(f'{task=} unknown')
+    directory = os.path.join(directory, f'task{task[-1]}', 'Matlab_files')
+    word_infor_path = directory + '/Word_Infor.csv'
+    word_infor_df = pd.read_csv(word_infor_path, sep='\t')
+    save_path = directory + '/scanpath.csv'
+
+    df = pd.DataFrame([], columns=['id', 'sn', 'nw', 'wn', 'fl', 'dur'])
+    for file in tqdm(sorted(os.listdir(directory))):
+        if not file.endswith('.mat'):
+            continue
+        subj = file.split('_')[0][-3:]
+        fpath = os.path.join(directory, file)
+        # read scanpath
+        if task.startswith('zuco1'):
+            mat_file = io.loadmat(
+                fpath, squeeze_me=True, struct_as_record=False,
+            )
+            sentence_data = mat_file['sentenceData']
+            for sn_idx in tqdm(range(len(sentence_data))):
+                sn_data = sentence_data[sn_idx]
+                # print(sn_data._fieldnames)
+                # skip empty scanpath
+                if pd.isna(sn_data.allFixations):
+                    continue
+                # sanity check with word infor file
+                assert word_infor_df[
+                    word_infor_df['SN'] == (
+                        sn_idx + 1
+                    )
+                ].iloc[0].WORD == sn_data.word[0].content, 'The sentence order is wrong!'
+                # get scanpath data for sentence
+                scanpath = sn_data.allFixations
+                # print(scanpath._fieldnames)
+                # check if scanpath is ndarray, otherwise convert scalar to ndarray
+                if isinstance(scanpath.x, np.ndarray):
+                    x = scanpath.x
+                    y = scanpath.y
+                    fix_dur = scanpath.duration
+                else:
+                    x = np.array([scanpath.x])
+                    y = np.array([scanpath.y])
+                    fix_dur = np.array([scanpath.duration])
+                # get word bounding positions
+                word_boundary = sn_data.wordbounds
+                num_word = word_boundary.shape[0]
+
+                # assign each fixation to the corresponding bounding boxes
+                for fix_idx in range(x.shape[0]):
+                    word_idx = np.where(
+                        (word_boundary[:, 0] <= x[fix_idx]) &
+                        (word_boundary[:, 2] >= x[fix_idx]) &
+                        (word_boundary[:, 1] <= y[fix_idx]) &
+                        (word_boundary[:, 3] >= y[fix_idx]),
+                    )
+                    assert len(word_idx) == 1, 'more than 1 word is matched!'
+                    # skip fixations outside all boundary boxes
+                    if word_idx[0].size == 0:
+                        continue
+                    fl = ((x[fix_idx] - word_boundary[word_idx, 0]) /
+                          (word_boundary[word_idx, 2] - word_boundary[word_idx, 0]))[0][0]
+                    df_tmp = pd.DataFrame(
+                        [[
+                            subj, sn_idx + 1, num_word, word_idx[0][0] + 1,
+                            fl, fix_dur[fix_idx],
+                        ]], columns=['id', 'sn', 'nw', 'wn', 'fl', 'dur'],
+                    )
+                    df = pd.concat([df, df_tmp])
+
+        else:
+            mat = h5py.File(fpath)
+            word_bound = mat['sentenceData/wordbounds']
+            scanpath_data = mat['sentenceData/allFixations']
+            for sn_idx in tqdm(range(len(scanpath_data))):
+                # compute word boundary
+                word_bound_sn_data = word_bound[sn_idx]
+                word_boundary = mat[word_bound_sn_data[0]][()]
+                word_boundary = np.swapaxes(word_boundary, 1, 0)
+                num_word = word_boundary.shape[0]
+
+                # compute scanpath
+                scanpath_sn_data = scanpath_data[sn_idx]
+                # skip empty scanpath
+                try:
+                    x = mat[scanpath_sn_data[0]]['x']
+                except KeyError:
+                    continue
+                y = mat[scanpath_sn_data[0]]['y']
+                fix_dur = mat[scanpath_sn_data[0]]['duration']
+
+                # iterate over each fixation, match to the corresponding word in the sentence
+                for fix_idx in range(len(x)):
+                    word_idx = np.where(
+                        (word_boundary[:, 0] <= x[fix_idx]) &
+                        (word_boundary[:, 2] >= x[fix_idx]) &
+                        (word_boundary[:, 1] <= y[fix_idx]) &
+                        (word_boundary[:, 3] >= y[fix_idx]),
+                    )
+                    assert len(word_idx) == 1, 'more than 1 word is matched!'
+                    # skip fixations outside all boundary boxes
+                    if word_idx[0].size == 0:
+                        continue
+                    fl = (
+                        (x[fix_idx] - word_boundary[word_idx, 0]) /
+                        (word_boundary[word_idx, 2] -
+                         word_boundary[word_idx, 0])
+                    )[0][0]
+                    df_tmp = pd.DataFrame(
+                        [[
+                            subj, sn_idx + 1, num_word, word_idx[0][0] + 1,
+                            fl, fix_dur[fix_idx][0],
+                        ]], columns=['id', 'sn', 'nw', 'wn', 'fl', 'dur'],
+                    )
+                    df = pd.concat([df, df_tmp])
+
+    df.to_csv(save_path, sep='\t', index=False)
+
+
+def load_zuco_word_and_scanpth_data(directory, task):
+    if task.startswith('zuco1'):
+        directory = directory + 'zuco/'
+    elif task == 'zuco21':
+        directory = directory + 'zuco2/'
+    else:
+        raise NotImplementedError(f'{task=} unknown')
+    directory = os.path.join(directory, f'task{task[-1]}', 'Matlab_files')
+    word_infor_path = directory + '/Word_Infor.csv'
+    word_infor_df = pd.read_csv(word_infor_path, sep='\t')
+    scanpath_path = directory + '/scanpath.csv'
+    scanpath_df = pd.read_csv(scanpath_path, sep='\t')
+    return word_infor_df, scanpath_df
+
+
+def add_current_fix_interest_area_label_for_sp(task: str = 'zuco12') -> None:
+    directory = C.path_to_zuco
+    word_info_df, eyemovement_df = load_zuco_word_and_scanpth_data(
+        directory=directory, task=task,
+    )
+    if task.startswith('zuco1'):
+        directory = directory + 'zuco/'
+    elif task == 'zuco21':
+        directory = directory + 'zuco2/'
+    else:
+        raise NotImplementedError(f'{task=} unknown')
+    directory = os.path.join(directory, f'task{task[-1]}', 'Matlab_files')
+    scanpath_path = directory + '/scanpath.csv'
+    save_path = scanpath_path
+    eyemovement_df['CURRENT_FIX_INTEREST_AREA_LABEL'] = ''
+    for idx, row in eyemovement_df.iterrows():
+        SN = row.sn
+        NW = row.wn
+        eyemovement_df.at[idx, 'CURRENT_FIX_INTEREST_AREA_LABEL'] = word_info_df.loc[
+            np.logical_and(
+                word_info_df.SN == SN, word_info_df.NW == NW,
+            )
+        ].WORD.values[0]
+
+    eyemovement_df.to_csv(save_path, sep='\t', index=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--zuco-task',
+        type=str,
+        choices=[
+            # zuco 1
+            'zuco11', 'zuco12',
+            # zuco 2
+            'zuco21',
+        ],
+    )
+    args = parser.parse_args()
+    print(f'Preparing word info for {args.zuco_task}...')
+    # create word information for all the sentences in each task, save to csv file in the same task folder
+    ZUCO_read_words(directory=C.path_to_zuco, task=args.zuco_task)
+    print(f'Preparing scanpath info for {args.zuco_task}...')
+    # create scanpath information for all subjects in each task, save to csv file in the same folder
+    ZUCO_read_scanpath(  # 12 subject
+        directory=C.path_to_zuco,
+        task=args.zuco_task,
+    )
+    print(f'Preparing add fix interest area label for {args.zuco_task}...')
+    add_current_fix_interest_area_label_for_sp(task=args.zuco_task)
+    print(f'Preparing add word length for {args.zuco_task}...')
+    add_word_len(directory=C.path_to_zuco, task=args.zuco_task)
+    # load data, task: zuco11, zuco12, zuco21
+    word_infor_df, scanpath_df = load_zuco_word_and_scanpth_data(
+        directory=C.path_to_zuco,
+        task=args.zuco_task,
+    )
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
I've added the following changes -- if you want me to remove some lmk and I'll change it

- [ ] added a `.gitignore`
- [ ] added `script/get_zuco_data.sh` to download and preprocess the zuco dataset -- including `scripts/zuco_create_wordinfor_scanpath_files.py`
- [ ] changed description to add celer data -- you need the READMEs and not only the python script
- [ ] unified the structure of each subsection in the README.md
- [ ] added a link to the arxiv version of the paper
- [ ] changed the training, inference, eval, and pl analysis commands to make them more readable (from my pov)
- [ ] moved all python scripts but `CONSTANTS.py` from the root directory to `scripts` and updated `README.md` accordingly
- [ ] updated the pl_analyses directory creating to account for non-existing `pl_analyses` folder
- [ ] updated pl_analyses bash scripts to account for new directory `model_analyses` and moved them to `scripts` -- updated `README.md` as well 
- [ ] minor styling changes in the python scripts